### PR TITLE
BAP-20293: Replace jms/cg with nette/php-generator

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -19,7 +19,7 @@
         "psr-4": {"": "src/"}
     },
     "require": {
-        "phpstan/phpstan": "0.11.*",
+        "phpstan/phpstan-shim": "0.11.*",
         "phpstan/phpstan-doctrine": "0.11.*",
         "ocramius/proxy-manager": "2.2.*"
     }

--- a/src/Oro/DI/SqlInjectionTestingConfigExtension.php
+++ b/src/Oro/DI/SqlInjectionTestingConfigExtension.php
@@ -2,8 +2,37 @@
 
 namespace Oro\DI;
 
-use Nette\DI\CompilerExtension;
-use Nette\DI\Config\Helpers;
+// We use phpstan/phpstan-shim as OroPlatform itself since 4.2 LTS has dependencies on nette packages:
+// https://github.com/phpstan/phpstan-shim
+// phpstan/phpstan-shim is shipped as a phar with all dependencies in randomly prefixed namespaces.
+//
+// This class (Oro\DI\SqlInjectionTestingConfigExtension) will most likely go away entirely
+// after upgrading to PHPStan 0.12 which no longer allows compiler extensions anyway.
+//
+// Internal reference to track PHPStan upgrade to 0.12 - OIS-417
+
+//use Nette\DI\CompilerExtension;
+//use Nette\DI\Config\Helpers;
+
+$compilerExtensionClass = null;
+$configHelpersClass = null;
+
+$classes = \get_declared_classes();
+foreach ($classes as $fqcn) {
+    if (null === $compilerExtensionClass && 'Nette\\DI\\CompilerExtension' === \substr($fqcn, -26)) {
+        $compilerExtensionClass = $fqcn;
+    }
+    if (null === $configHelpersClass && 'Nette\\DI\\Config\\Helpers' === \substr($fqcn, -23)) {
+        $configHelpersClass = $fqcn;
+    }
+    if (null !== $compilerExtensionClass && null !== $configHelpersClass) {
+        break;
+    }
+}
+
+\class_alias($compilerExtensionClass, 'Oro\DI\CompilerExtension');
+\class_alias($configHelpersClass, 'Oro\DI\Helpers');
+
 use Oro\TrustedDataConfigurationFinder;
 
 /**

--- a/src/Oro/TrustedDataConfigurationFinder.php
+++ b/src/Oro/TrustedDataConfigurationFinder.php
@@ -3,7 +3,6 @@
 namespace Oro;
 
 use Composer\Autoload\ClassLoader;
-use Nette\Utils\Finder;
 
 /**
  * Return path to trusted_data configuration files stored in all paths registered in composer autoloaders.
@@ -22,8 +21,11 @@ class TrustedDataConfigurationFinder
 
         $files = [];
         /** @var \SplFileInfo $trustedDataConfigFile */
-        foreach (Finder::findFiles(self::TRUSTED_DATA_SEARCH_PATTERN)->from($directories) as $trustedDataConfigFile) {
-            $files[] = $trustedDataConfigFile->getRealPath();
+        foreach ($directories as $dir) {
+            $file = $dir . '/' . self::TRUSTED_DATA_SEARCH_PATTERN;
+            if (\is_readable($file)) {
+                $files[] = $file;
+            }
         }
 
         return $files;

--- a/src/Oro/TrustedDataConfigurationFinder.php
+++ b/src/Oro/TrustedDataConfigurationFinder.php
@@ -22,7 +22,7 @@ class TrustedDataConfigurationFinder
         $files = [];
         /** @var \SplFileInfo $trustedDataConfigFile */
         foreach ($directories as $dir) {
-            $file = $dir . '/' . self::TRUSTED_DATA_SEARCH_PATTERN;
+            $file = $dir . DIRECTORY_SEPARATOR . self::TRUSTED_DATA_SEARCH_PATTERN;
             if (\is_readable($file)) {
                 $files[] = $file;
             }


### PR DESCRIPTION
We use phpstan/phpstan-shim as OroPlatform itself since 4.2 LTS has dependencies on nette packages.
https://magecore.atlassian.net/browse/BAP-20293